### PR TITLE
Update test_download.py

### DIFF
--- a/tests/mediadb/test_download.py
+++ b/tests/mediadb/test_download.py
@@ -1,3 +1,5 @@
+import os
+from unittest import skip
 from tests.utils import connect_db_args
 from xklb.createdb.tube_add import tube_add
 from xklb.lb import library as lb
@@ -7,7 +9,7 @@ STORAGE_PREFIX = "tests/data/"
 
 dl_db = "tests/data/dl.db"
 
-
+@skip("network")
 def test_yt():
     tube_add([dl_db, URL])
     lb(
@@ -16,7 +18,7 @@ def test_yt():
             dl_db,
             "--video",
             f"--prefix={STORAGE_PREFIX}",
-            "--no-write-thumbnail",  # TODO: test that yt-dlp option is forwarded
+            "--write-thumbnail",
             "--force",
             "--subs",
             "-s",
@@ -28,3 +30,7 @@ def test_yt():
 
     captions = list(args.db.query("select * from captions"))
     assert {"media_id": 2, "time": 3, "text": "For more information contact phihag@phihag.de"} in captions
+
+    video_id = "BaW_jenozKc"
+    thumbnail_path = os.path.join(STORAGE_PREFIX, "Youtube", "Philipp Hagemeister", f"{video_id}.jpg")
+    assert os.path.exists(thumbnail_path), "Thumbnail file does not exist"

--- a/tests/mediadb/test_download.py
+++ b/tests/mediadb/test_download.py
@@ -9,7 +9,6 @@ STORAGE_PREFIX = "tests/data/"
 
 dl_db = "tests/data/dl.db"
 
-@skip("network")
 def test_yt():
     tube_add([dl_db, URL])
     lb(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR includes changes to the test script to ensure that the `--write-thumbnail` option in xklb is properly tested. The test now asserts the existence of the thumbnail file after the download process.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required to verify that the `--write-thumbnail` option works as expected. Ensuring the thumbnail file is downloaded correctly helps finding it by third party tool ([iiab/calibre-web](https://github.com/iiab/calibre-web) for example)
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
The changes were tested by running the updated test script in an environment with internet access. The test downloads a video from YouTube and checks for the existence of the thumbnail file in the specified directory. The test verifies the following:

- The video and subtitles are downloaded correctly.
- The specified thumbnail file is created and exists in the storage directory.

<!--- Include details of your testing environment, tests ran to see how -->
Testing environment:
- Operating System: Ubuntu 24.10
- Python Version: 3.12.3
- xklb Version: 2.8.050
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/chapmanjacobd/library/assets/16546989/64c4d60f-9eed-453c-9478-21dbcc274d8e)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
