### PR TITLE
fix: correct boolean conversion in ArgparseDict

### DIFF
--- a/library/utils/argparse_utils.py
+++ b/library/utils/argparse_utils.py
@@ -58,7 +58,7 @@ class ArgparseDict(argparse.Action):
                 if any(sym in v for sym in (" [", " {")):
                     d[k] = load_string(v)
                 elif v_strip in ("True", "False"):
-                    d[k] = bool(v_strip)
+                    d[k] = v_strip == "True"
                 elif v_strip.isnumeric():
                     d[k] = nums.safe_int_float_str(v_strip)
                 else:

--- a/tests/utils/test_argparse_utils.py
+++ b/tests/utils/test_argparse_utils.py
@@ -27,3 +27,25 @@ def test_argparse_slice():
         parser.parse_args(["--slice", ""])
     with pytest.raises((argparse.ArgumentError, SystemExit)):
         parser.parse_args(["--slice"])
+
+
+def test_argparse_dict_boolean_conversion():
+    """Test that ArgparseDict correctly converts string 'True' and 'False' to boolean."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", action=argparse_utils.ArgparseDict)
+
+    # Test True conversion
+    args = parser.parse_args(["--config", "key1=True"])
+    assert args.config == {"key1": True}
+    assert isinstance(args.config["key1"], bool)
+
+    # Test False conversion - this is the bug: bool("False") returns True
+    args = parser.parse_args(["--config", "key2=False"])
+    assert args.config == {"key2": False}
+    assert isinstance(args.config["key2"], bool)
+
+    # Test mixed types
+    args = parser.parse_args(["--config", "enabled=True disabled=False count=42"])
+    assert args.config == {"enabled": True, "disabled": False, "count": 42}
+    assert args.config["enabled"] is True
+    assert args.config["disabled"] is False


### PR DESCRIPTION
## Summary

- Fix `ArgparseDict` converting string `'False'` to boolean `True`
- `bool('False')` returns `True` in Python because non-empty strings are truthy
- Changed from `bool(v_strip)` to `v_strip == 'True'` for correct string-to-bool conversion

## Test plan

- [x] New test for `'True'` and `'False'` string-to-bool conversion
- [x] Existing tests pass