### PR TITLE
Add a release-notes workflow

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,18 @@
+name: Release Notes
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: changelogfa.st Release Notes
+        uses: changelogfast/changelog-fast-action@v1
+        with:
+          output: release
+          style: technical


### PR DESCRIPTION
Hey

I'm Stéphane — I build changelogfa.st, and I'm trying to make my project contribute to open source projects.

You release often, and I noticed the last few (v3.0.167 → v3.0.171) go out with empty notes. That's a lot of versions where folks pulling the update don't get to see what changed. I'd like to help fix that.

This PR adds a small workflow that, on each published release, writes a short readable summary into the release body — grouped by type, none of the commit-hash soup.

Here is an example of automated release note: [https://github.com/changelogfast/changelog-fast-action/releases/tag/v1.1.1](https://github.com/changelogfast/changelog-fast-action/releases/tag/v1.1.1)

Being upfront so there are no surprises: the Action is mine, so I'm not a neutral party here. It's free for open source and I'm genuinely just trying to get it in the hands of projects like yours. The one catch is it needs the changelogfa.st GitHub App installed to run — the notes are generated server-side, which is also why the workflow needs no secrets, just `id-token: write`.

I left it as a draft on purpose: it won't do anything until the App is installed, and I didn't want to drop a half-wired workflow on you. No hard feelings at all if it's not for you — close away. If you'd like to try it, install the App and mark it ready, and I'll keep an eye on it in case anything needs adjusting.

Totally happy to adapt it to how you work — open a CHANGELOG.md PR instead of editing the release, change the style, whatever's useful.

[https://changelogfa.st](https://changelogfa.st/)

Best,
Stéphane
